### PR TITLE
ADD basic EventKitManager class for accessing user calendars

### DIFF
--- a/CalendarQuickView.xcodeproj/project.pbxproj
+++ b/CalendarQuickView.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		2FDFB0942730241F00BE49CC /* CalendarQuickWidget.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = 2FDFB08E2730241C00BE49CC /* CalendarQuickWidget.intentdefinition */; };
 		2FDFB0972730241F00BE49CC /* CalendarQuickWidgetExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 2FDFB0852730241B00BE49CC /* CalendarQuickWidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		2FDFB09D2730B09800BE49CC /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FDFB09C2730B09800BE49CC /* SettingsView.swift */; };
+		41EA3BC027336B77001070CF /* EventKitManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41EA3BBF27336B77001070CF /* EventKitManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -80,6 +81,7 @@
 		2FDFB0912730241F00BE49CC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		2FDFB0922730241F00BE49CC /* CalendarQuickWidget.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = CalendarQuickWidget.entitlements; sourceTree = "<group>"; };
 		2FDFB09C2730B09800BE49CC /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		41EA3BBF27336B77001070CF /* EventKitManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventKitManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -146,6 +148,7 @@
 		2FCC6CE1272C3A08006D5C7D /* CalendarQuickView */ = {
 			isa = PBXGroup;
 			children = (
+				41EA3BBF27336B77001070CF /* EventKitManager.swift */,
 				2FCC6CE2272C3A08006D5C7D /* AppDelegate.swift */,
 				2F6FB93627320EEE00DD0ACC /* Views */,
 				2F6FB93527320EDC00DD0ACC /* Extensions */,
@@ -323,6 +326,7 @@
 				2FDFB09D2730B09800BE49CC /* SettingsView.swift in Sources */,
 				2F6FB94727322C7700DD0ACC /* CalendarView.swift in Sources */,
 				2FCC6CFE272C4801006D5C7D /* Calendar-Extension.swift in Sources */,
+				41EA3BC027336B77001070CF /* EventKitManager.swift in Sources */,
 				2FDFB0942730241F00BE49CC /* CalendarQuickWidget.intentdefinition in Sources */,
 				2FCC6CE3272C3A08006D5C7D /* AppDelegate.swift in Sources */,
 			);

--- a/CalendarQuickView/AppDelegate.swift
+++ b/CalendarQuickView/AppDelegate.swift
@@ -46,6 +46,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         self.statusBarItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         self.statusBarItem?.menu = menu
         self.statusBarItem?.button?.image = NSImage(systemSymbolName: "calendar", accessibilityDescription: "Quick View Calendar")
+        
+        EventKitManager.shared.checkCalendarAuthStatus()
+        
+    
     }
     
     func menuWillOpen(_ menu: NSMenu) {

--- a/CalendarQuickView/CalendarQuickView.entitlements
+++ b/CalendarQuickView/CalendarQuickView.entitlements
@@ -6,5 +6,7 @@
 	<true/>
 	<key>com.apple.security.files.user-selected.read-only</key>
 	<true/>
+	<key>com.apple.security.personal-information.calendars</key>
+	<true/>
 </dict>
 </plist>

--- a/CalendarQuickView/EventKitManager.swift
+++ b/CalendarQuickView/EventKitManager.swift
@@ -1,0 +1,59 @@
+//
+//  EventKitManager.swift
+//  CalendarQuickView
+//
+//  Created by David Malicke on 11/1/21.
+//
+
+import Foundation
+import EventKit
+
+class EventKitManager {
+    
+    static let shared = EventKitManager()
+    
+    let eventStore = EKEventStore()
+    
+    var calendars: [EKCalendar]?
+    
+    func checkCalendarAuthStatus() {
+        let status = EKEventStore.authorizationStatus(for: EKEntityType.event)
+        
+        switch(status) {
+            
+        case EKAuthorizationStatus.notDetermined:
+            //first run
+            requestAccessToCalendar()
+            
+        case EKAuthorizationStatus.authorized:
+            print("Authorized")
+            
+        case EKAuthorizationStatus.restricted, EKAuthorizationStatus.denied:
+            
+            break
+            
+        @unknown default:
+            fatalError()
+        }
+        
+    }
+    
+    func requestAccessToCalendar() {
+        eventStore.requestAccess(to: .event) { accessGranted, error in
+            
+            if accessGranted == true {
+                DispatchQueue.main.async {
+                    print("success")
+                    self.calendars = self.eventStore.calendars(for: EKEntityType.event)
+                    print("\(String(describing: self.calendars?.count))")
+                    print(self.calendars![0].title)
+                    
+                }
+            } else {
+                DispatchQueue.main.async {
+                    print("fail")
+                }
+            }
+        }
+    }
+}

--- a/CalendarQuickView/Info.plist
+++ b/CalendarQuickView/Info.plist
@@ -4,6 +4,12 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>NSRemindersUsageDescription</key>
+	<string>CalendarQuickView would like access to your reminders.</string>
+	<key>NSCalendarsUsageDescription</key>
+	<string>CalendarQuickView would like access to your calendars.</string>
+	<key>NSContactsUsageDescription</key>
+	<string>CalendarQuickView would like access to your contacts.</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIconFile</key>


### PR DESCRIPTION
I'm hoping this pull request works, sorry about all the trouble with this.

This includes a basic EventKitManager class for accessing user calendars. You can disable it by commenting out the call in the AppDelegate. 

